### PR TITLE
strip build-id in the linker script

### DIFF
--- a/common.ld
+++ b/common.ld
@@ -22,6 +22,7 @@ SECTIONS
     /DISCARD/ :
     {
       *(.ARM.exidx*)
+      *(.note.gnu.build-id*)
     }
 
     __STACK_START = ORIGIN(ram) + LENGTH(ram);

--- a/stm32f100.json
+++ b/stm32f100.json
@@ -12,7 +12,6 @@
   "no-compiler-rt": true,
   "pre-link-args": [
     "-Tstm32f100.ld",
-    "-Wl,--build-id=none",
     "-Wl,--gc-sections",
     "-mcpu=cortex-m3",
     "-mthumb",


### PR DESCRIPTION
instead of disabling it via a linker flag
