### PR TITLE
remove --gc-sections for the target specification file

### DIFF
--- a/stm32f100.json
+++ b/stm32f100.json
@@ -12,7 +12,6 @@
   "no-compiler-rt": true,
   "pre-link-args": [
     "-Tstm32f100.ld",
-    "-Wl,--gc-sections",
     "-mcpu=cortex-m3",
     "-mthumb",
     "-nostartfiles"


### PR DESCRIPTION
this flag is already pass to the linker invocation
