### PR TITLE
__reset -> start

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,4 +1,3 @@
 tar ext :3333
-break __reset
 load
 step

--- a/common.ld
+++ b/common.ld
@@ -1,5 +1,3 @@
-ENTRY(__reset)
-
 __DATA_LOAD = LOADADDR(.data);
 
 SECTIONS

--- a/src/bin/00-empty.rs
+++ b/src/bin/00-empty.rs
@@ -3,7 +3,7 @@
 extern crate cu;
 
 #[no_mangle]
-pub unsafe extern "C" fn __reset() {
+pub unsafe extern "C" fn start() {
     loop {}
 }
 

--- a/src/bin/01-led.rs
+++ b/src/bin/01-led.rs
@@ -5,7 +5,7 @@ extern crate cu;
 use cu::register;
 
 #[no_mangle]
-pub unsafe extern "C" fn __reset() {
+pub unsafe extern "C" fn start() {
     let ref mut rcc = register::RCC;
     let ref mut gpioc = register::GPIOC;
 

--- a/src/bin/02-busy-timer.rs
+++ b/src/bin/02-busy-timer.rs
@@ -5,7 +5,7 @@ extern crate cu;
 use cu::{bb, register};
 
 #[no_mangle]
-pub unsafe extern "C" fn __reset() {
+pub unsafe extern "C" fn start() {
     setup();
 
     loop_();

--- a/src/bin/03-timer-interrupt.rs
+++ b/src/bin/03-timer-interrupt.rs
@@ -5,7 +5,7 @@ extern crate cu;
 use cu::{asm, bb, register};
 
 #[no_mangle]
-pub unsafe extern "C" fn __reset() {
+pub unsafe extern "C" fn start() {
     setup();
 
     loop_();

--- a/src/bin/04-button.rs
+++ b/src/bin/04-button.rs
@@ -5,7 +5,7 @@ extern crate cu;
 use cu::{bb, register};
 
 #[no_mangle]
-pub unsafe extern "C" fn __reset() {
+pub unsafe extern "C" fn start() {
     setup();
     loop_();
 }

--- a/src/bin/05-init-data.rs
+++ b/src/bin/05-init-data.rs
@@ -3,7 +3,7 @@
 extern crate cu;
 
 #[no_mangle]
-pub unsafe extern "C" fn __reset() {
+pub unsafe extern "C" fn start() {
     cu::rt::init_data();
 
     loop {}

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -5,7 +5,7 @@ use asm;
 extern "C" {
     fn __STACK_START();
     /// Reset
-    pub fn __reset();
+    pub fn start();
     /// Non-maskable interrupt
     pub fn __nmi();
     /// Hard fault
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn __default_handler() {
 #[link_section = ".exceptions"]
 #[no_mangle]
 pub static __EXCEPTIONS: [Option<unsafe extern "C" fn()>; 16] = [Some(__STACK_START),
-                                                                 Some(__reset),
+                                                                 Some(start),
                                                                  None,
                                                                  None,
                                                                  None,


### PR DESCRIPTION
start is the standard name for the entry point of a program so we can
omit the explicit declaration of 'ENTRY' in the linker script.
