### PR TITLE
ld: split stack pointer value from .exceptions

### DIFF
--- a/common.ld
+++ b/common.ld
@@ -4,6 +4,9 @@ SECTIONS
 {
     .text : ALIGN(4)
     {
+        link_stack_pointer_start = .;
+        KEEP(*(.stack_pointer))
+        link_stack_pointer_end = .;
         link_exceptions_start = .;
         KEEP(*(.exceptions))
         link_exceptions_end = .;
@@ -31,7 +34,9 @@ SECTIONS
 }
 
 /* Sanity checks */
-ASSERT ( link_exceptions_start == ORIGIN(FLASH), "exceptions not where expected" );
+ASSERT ( link_stack_pointer_start == ORIGIN(FLASH), "stack pointer not where expected" );
+ASSERT ( link_exceptions_start - ORIGIN(FLASH) == 4, "exceptions not where expected" );
 ASSERT ( link_interrupts_start - ORIGIN(FLASH) == 0x40, "interrupts not where expected" );
+ASSERT ( link_stack_pointer_start < link_stack_pointer_end, "stack pointer not linked in" );
 ASSERT ( link_exceptions_start < link_exceptions_end, "exceptions not linked in" );
 ASSERT ( link_interrupts_start < link_interrupts_end, "interrupts not linked in" );

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -3,7 +3,8 @@
 use asm;
 
 extern "C" {
-    fn __STACK_START();
+    /// The start of the stack
+    static __STACK_START: u32;
     /// Reset
     pub fn start();
     /// Non-maskable interrupt
@@ -18,11 +19,15 @@ pub unsafe extern "C" fn __default_handler() {
     asm::bkpt();
 }
 
+/// Points at the start of the stack. This is used as the initial value of the stack pointer.
+#[link_section = ".stack_pointer"]
+#[no_mangle]
+pub static __STACK_POINTER: &'static u32 = &__STACK_START;
+
 /// Cortex-M processor exceptions
 #[link_section = ".exceptions"]
 #[no_mangle]
-pub static __EXCEPTIONS: [Option<unsafe extern "C" fn()>; 16] = [Some(__STACK_START),
-                                                                 Some(start),
+pub static __EXCEPTIONS: [Option<unsafe extern "C" fn()>; 15] = [Some(start),
                                                                  None,
                                                                  None,
                                                                  None,


### PR DESCRIPTION
because they have different types
