### PR TITLE
ci: use a newer docker image

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -3,7 +3,7 @@
 set -ex
 
 main() {
-    local tag=2016-04-26
+    local tag=2016-05-03
 
     # The particle user has id = 1000, but this may not match the travis user id. To workaround this
     # issue, make everything world write-able.
@@ -12,8 +12,6 @@ main() {
     docker run \
            -v $(pwd):/mnt \
            -w /mnt \
-           -e AR_thumbv7m_none_eabi=arm-none-eabi-ar \
-           -e CC_thumbv7m_none_eabi=arm-none-eabi-gcc \
            japaric/copper:$tag \
            bash -ex -c '
 rustup default nightly


### PR DESCRIPTION
now we don't need to set AR and CC env variables
