### PR TITLE
simplify target specification file

### DIFF
--- a/thumbv7m-none-eabi.json
+++ b/thumbv7m-none-eabi.json
@@ -12,8 +12,6 @@
     "pre-link-args": [
         "-Wl,-(",
         "-Tstm32f100.ld",
-        "-mcpu=cortex-m3",
-        "-mthumb",
         "-nostartfiles"
     ],
     "post-link-args": [


### PR DESCRIPTION
The removed args control codegen but don't have any effect because at link time
everything have been compiled already.
