### PR TITLE
make the `start` function divergent

### DIFF
--- a/common.ld
+++ b/common.ld
@@ -7,6 +7,9 @@ SECTIONS
         link_stack_pointer_start = .;
         KEEP(*(.stack_pointer))
         link_stack_pointer_end = .;
+        link_reset_start = .;
+        KEEP(*(.reset))
+        link_reset_end = .;
         link_exceptions_start = .;
         KEEP(*(.exceptions))
         link_exceptions_end = .;
@@ -35,8 +38,10 @@ SECTIONS
 
 /* Sanity checks */
 ASSERT ( link_stack_pointer_start == ORIGIN(FLASH), "stack pointer not where expected" );
-ASSERT ( link_exceptions_start - ORIGIN(FLASH) == 4, "exceptions not where expected" );
+ASSERT ( link_reset_start - ORIGIN(FLASH) == 4, "reset not where expected" );
+ASSERT ( link_exceptions_start - ORIGIN(FLASH) == 8, "exceptions not where expected" );
 ASSERT ( link_interrupts_start - ORIGIN(FLASH) == 0x40, "interrupts not where expected" );
 ASSERT ( link_stack_pointer_start < link_stack_pointer_end, "stack pointer not linked in" );
+ASSERT ( link_reset_start < link_reset_end, "reset not linked in" );
 ASSERT ( link_exceptions_start < link_exceptions_end, "exceptions not linked in" );
 ASSERT ( link_interrupts_start < link_interrupts_end, "interrupts not linked in" );

--- a/src/bin/00-empty.rs
+++ b/src/bin/00-empty.rs
@@ -3,7 +3,7 @@
 extern crate cu;
 
 #[no_mangle]
-pub extern "C" fn start() {
+pub extern "C" fn start() -> ! {
     loop {}
 }
 

--- a/src/bin/01-led.rs
+++ b/src/bin/01-led.rs
@@ -5,7 +5,7 @@ extern crate cu;
 use cu::register;
 
 #[no_mangle]
-pub extern "C" fn start() {
+pub extern "C" fn start() -> ! {
     unsafe {
         let ref mut rcc = register::RCC;
         let ref mut gpioc = register::GPIOC;

--- a/src/bin/02-busy-timer.rs
+++ b/src/bin/02-busy-timer.rs
@@ -5,7 +5,7 @@ extern crate cu;
 use cu::{bb, register};
 
 #[no_mangle]
-pub extern "C" fn start() {
+pub extern "C" fn start() -> ! {
     unsafe {
         setup();
     }
@@ -31,7 +31,7 @@ unsafe fn setup() {
     tim7.cr1.write(*register::tim::cr1::DEFAULT.cen(true));
 }
 
-fn loop_() {
+fn loop_() -> ! {
     let ref uif = bb::TIM7.sr.uif;
     let ref pc8 = bb::GPIOC.odr[8];
 

--- a/src/bin/03-timer-interrupt.rs
+++ b/src/bin/03-timer-interrupt.rs
@@ -5,7 +5,7 @@ extern crate cu;
 use cu::{asm, bb, register};
 
 #[no_mangle]
-pub extern "C" fn start() {
+pub extern "C" fn start() -> ! {
     unsafe {
         setup();
     }
@@ -36,7 +36,7 @@ unsafe fn setup() {
     tim7.cr1.write(*register::tim::cr1::DEFAULT.cen(true));
 }
 
-fn loop_() {
+fn loop_() -> ! {
     let ref pc8 = bb::GPIOC.odr[8];
 
     loop {

--- a/src/bin/04-button.rs
+++ b/src/bin/04-button.rs
@@ -5,7 +5,7 @@ extern crate cu;
 use cu::{bb, register};
 
 #[no_mangle]
-pub extern "C" fn start() {
+pub extern "C" fn start() -> ! {
     unsafe {
         setup();
     }
@@ -23,7 +23,7 @@ unsafe fn setup() {
     gpioc.crh.write(*register::gpio::crh::DEFAULT.cnf(8, 0b00).mode(8, 0b10));
 }
 
-fn loop_() {
+fn loop_() -> ! {
     let ref pa0 = bb::GPIOA.idr[0];
     let ref pc8 = bb::GPIOC.odr[8];
 

--- a/src/bin/05-init-data.rs
+++ b/src/bin/05-init-data.rs
@@ -3,7 +3,7 @@
 extern crate cu;
 
 #[no_mangle]
-pub extern "C" fn start() {
+pub extern "C" fn start() -> ! {
     unsafe {
         cu::rt::init_data();
     }

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -6,7 +6,7 @@ extern "C" {
     /// The start of the stack
     static __STACK_START: u32;
     /// Reset
-    pub fn start();
+    pub fn start() -> !;
     /// Non-maskable interrupt
     pub fn __nmi();
     /// Hard fault
@@ -24,11 +24,15 @@ pub unsafe extern "C" fn __default_handler() {
 #[no_mangle]
 pub static __STACK_POINTER: &'static u32 = &__STACK_START;
 
+/// Program entry point: The reset function.
+#[link_section = ".reset"]
+#[no_mangle]
+pub static __RESET: Option<unsafe extern "C" fn() -> !> = Some(start);
+
 /// Cortex-M processor exceptions
 #[link_section = ".exceptions"]
 #[no_mangle]
-pub static __EXCEPTIONS: [Option<unsafe extern "C" fn()>; 15] = [Some(start),
-                                                                 None,
+pub static __EXCEPTIONS: [Option<unsafe extern "C" fn()>; 14] = [None,
                                                                  None,
                                                                  None,
                                                                  None,


### PR DESCRIPTION
returning from `start` is undefined behavior so this change makes it impossible
to shoot ourselves in the foot.
