### PR TITLE
use core::ptr instead of core::intrinsics

### DIFF
--- a/src/bb/mod.rs
+++ b/src/bb/mod.rs
@@ -1,6 +1,6 @@
 //! Bit-banded peripherals
 
-use core::intrinsics;
+use core::ptr;
 
 pub mod gpio;
 pub mod rcc;
@@ -20,7 +20,7 @@ pub struct Ro(u32);
 impl Ro {
     /// Checks if the bit is set
     pub fn is_set(&self) -> bool {
-        unsafe { intrinsics::volatile_load(&self.0) != 0 }
+        unsafe { ptr::read_volatile(&self.0) != 0 }
     }
 }
 
@@ -32,19 +32,19 @@ impl Rw {
     /// Clears the bit
     pub fn clear(&self) {
         unsafe {
-            intrinsics::volatile_store(&self.0 as *const _ as *mut _, 0);
+            ptr::write_volatile(&self.0 as *const _ as *mut _, 0);
         }
     }
 
     /// Checks if the bit is set
     pub fn is_set(&self) -> bool {
-        unsafe { intrinsics::volatile_load(&self.0) != 0 }
+        unsafe { ptr::read_volatile(&self.0) != 0 }
     }
 
     /// Sets the bit
     pub fn set(&self) {
         unsafe {
-            intrinsics::volatile_store(&self.0 as *const _ as *mut _, 1);
+            ptr::write_volatile(&self.0 as *const _ as *mut _, 1);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 //! STM32VLDISCOVERY
 
 #![feature(asm)]
-#![feature(core_intrinsics)]
 #![feature(lang_items)]
 
 #![allow(dead_code)]

--- a/src/register/itm/port.rs
+++ b/src/register/itm/port.rs
@@ -1,6 +1,6 @@
 //! Stimulus port
 
-use core::intrinsics;
+use core::ptr;
 
 /// Register
 #[repr(C)]
@@ -9,13 +9,13 @@ pub struct Register(u32);
 impl Register {
     /// Checks if the stimulus port FIFO is full
     pub fn is_full(&self) -> bool {
-        unsafe { intrinsics::volatile_load(&self.0) == 0 }
+        unsafe { ptr::read_volatile(&self.0) == 0 }
     }
 
     /// Writes a character to the stimulus port FIFO
     pub fn write(&mut self, c: u8) {
         unsafe {
-            intrinsics::volatile_store(&mut self.0 as *mut _ as *mut u8, c);
+            ptr::write_volatile(&mut self.0 as *mut _ as *mut u8, c);
         }
     }
 }

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -1,6 +1,6 @@
 //! Registers
 
-use core::intrinsics;
+use core::ptr;
 
 macro_rules! bits {
     ($($name:ident: $offset:expr),+,) => {
@@ -42,7 +42,7 @@ impl<T> Rw<T>
 {
     /// Reads the register value
     pub fn read(&self) -> T {
-        unsafe { intrinsics::volatile_load(&self.0) }
+        unsafe { ptr::read_volatile(&self.0) }
     }
 
     /// Updates the register value
@@ -59,7 +59,7 @@ impl<T> Rw<T>
         where T: From<U>
     {
         unsafe {
-            intrinsics::volatile_store(&mut self.0, T::from(value));
+            ptr::write_volatile(&mut self.0, T::from(value));
         }
     }
 }
@@ -76,7 +76,7 @@ impl<T> Wo<T>
         where T: From<U>
     {
         unsafe {
-            intrinsics::volatile_store(&mut self.0, T::from(value));
+            ptr::write_volatile(&mut self.0, T::from(value));
         }
     }
 }

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -1,6 +1,6 @@
 //! Runtime
 
-use core::intrinsics;
+use core::ptr;
 
 /// Abort
 pub fn abort() -> ! {
@@ -23,5 +23,5 @@ pub unsafe fn init_data() {
     let n = (&__DATA_END as *const _ as usize).wrapping_sub(&__DATA_START as *const _ as usize) >>
             2;
 
-    intrinsics::copy_nonoverlapping(&__DATA_LOAD, &mut __DATA_START, n);
+    ptr::copy_nonoverlapping(&__DATA_LOAD, &mut __DATA_START, n);
 }


### PR DESCRIPTION
the volatile load/store stuff has been stabilized! Yay, one less feature
gate.
