### PR TITLE
replace compiler-rt.rs with rustc-builtins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ name = "cu"
 version = "0.1.0"
 
 [dependencies]
-compiler-rt = { git = "https://github.com/japaric/compiler-rt.rs" }
 rlibc = "1.0.0"
+rustc_builtins = { git = "https://github.com/japaric/rustc-builtins" }
 
 [profile.release]
 lto = true

--- a/cortex-m3.json
+++ b/cortex-m3.json
@@ -5,6 +5,7 @@
     "executables": true,
     "linker": "arm-none-eabi-gcc",
     "llvm-target": "thumbv7m-none-eabi",
+    "no-compiler-rt": true,
     "os": "none",
     "post-link-args": ["-Wl,-)"],
     "pre-link-args": ["-Wl,-(", "-Tstm32f100.ld", "-nostartfiles"],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![no_std]
 
+extern crate rustc_builtins;
 extern crate rlibc;
 
 pub mod asm;


### PR DESCRIPTION
the latter is way easier to compile; it doesn't depend on an external C
cross compiler (or git)
